### PR TITLE
add "adt" python script to take config file to add metadata to aiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
-# Audio Deployment Tool
+# Audio Deployment Tool (ADT)
 ## About
 A tool for automating metadata for audio specifically to reduce the complexity and error prone nature of preparing audio files for release.
 
+## Installation
+### venv (optional)
+#### MacOS/Linux
+```
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### Requirements
+```
+pip3 install -r requirements.txt
+```
+
+### Usage
+#### Config file
+Tags can be added automatically with a config file by running:
+
+```
+./adt -c <config file>.yml
+```
+
+see example config: `example_config.yaml`
 

--- a/adt
+++ b/adt
@@ -1,0 +1,100 @@
+#! /usr/bin/env python3
+import argparse
+import os
+
+from mutagen.id3 import ID3, TRCK, TDRC, TIT2, TALB, TPE1, TPOS, TCON, TCOM, TPOS, TCOP, COMM, TXXX, APIC
+from mutagen.aiff import AIFF
+from yaml import load, dump
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+
+def get_args():
+    class ValidateConfigFilename(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            if not values.endswith(".yml") and not values.endswith(".yaml"):
+                raise ValueError("input must be an .yml or .yaml")
+            setattr(namespace, self.dest, values)
+
+
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('-c', "--config", type=str, action=ValidateConfigFilename, help='process based on yaml config file')
+    parser.add_argument('-f', "--force", action="store_true", help='force overwrite of tags')
+    parser.add_argument('-v', "--verbose", action="store_true", help='print metadata tags (except cover image)')
+    return parser.parse_args()
+
+
+def add_tags(audio, info, force=False):
+    if audio.tags and not force:
+        raise ValueError("tags already exist and force option is not set to true")
+
+    if audio.tags:
+        audio.tags = None
+
+    audio.add_tags()
+
+    audio.tags.add(TRCK(encoding=3, text=info['track']))
+    audio.tags.add(TDRC(encoding=3, text=info['year']))
+    audio.tags.add(TIT2(encoding=3, text=info['title']))
+    audio.tags.add(TALB(encoding=3, text=info['album name']))
+    audio.tags.add(TPE1(encoding=3, text=info['artist name']))
+    audio.tags.add(TPOS(encoding=3, text=info['serial number']))
+    audio.tags.add(TCON(encoding=3, text=info['genre']))
+    audio.tags.add(TCOM(encoding=3, text=info['composer'])) 
+    audio.tags.add(TCOP(encoding=3, text=info['copyright'])) 
+    audio.tags.add(TXXX(encoding=3, desc=u'CATALOGNUMBER', text=info['catalog number'])) 
+    audio.tags.add(COMM(encoding=3, desc=u'eng', text=info['comment']))
+
+    _, file_extension = os.path.splitext(info['cover art'])
+    with open(info['cover art'], 'rb') as cover:
+        audio.tags.add(APIC(
+                      encoding=3,
+                      mime=f'image/{file_extension[1:]}',
+                      type=3, 
+                      desc=u'Cover',
+                      data=cover.read()
+                    ))
+
+    audio.save()
+
+def print_tags(audio):
+    for key in audio.tags.keys():
+        if "APIC" in key:
+            continue
+        print(key, audio.tags[key])
+
+
+def create_yaml(audio):
+    return ""
+
+if __name__ == '__main__':
+    try:
+        args = get_args()
+    except Exception as e:
+        print(e)
+        exit()
+
+    if(args.config): 
+        with open(args.config, 'r') as stream:
+            config = load(stream, Loader=Loader)
+
+        for track_index in config["tracks"]:
+            info = config["all"].copy()
+            info["track"] = track_index
+
+            track_data = config["tracks"][track_index]
+            file = track_data.pop('file', None)
+            info.update(track_data)
+            
+            info = {k: str(v).encode("utf-8").decode('utf-8') for k,v in info.items()}
+            audio = AIFF(file, v2_version=3)
+            try:
+                add_tags(audio, info, args.force)
+            except Exception as e:
+                print(e)
+                exit()
+            
+            if(args.verbose): 
+                print_tags(audio)      

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,0 +1,20 @@
+all:
+  year: 2025
+  album name: An Album Name
+  artist name: An Artist Name
+  copyright: Some Copywrite Info
+  serial number: 012345
+  composer: The Composer
+  genre: house
+  comment: here's where you add extra notes
+  catalog number: LOL001
+  cover art: some_albumart.png # this can include a path
+
+tracks:
+  1:
+    title: a track title
+    file: track1.aiff
+    comment: individual track data ovewrites master
+  2:
+    title: a second track title
+    file: track2.aiff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mutagen
+
+pyyaml


### PR DESCRIPTION
The config file (format show in "example_config.yaml") provides all the information (including location of audio tracks).

The original audio track is saved to when running this process.

additionally:
* add dependencies
* update README with installation steps